### PR TITLE
docs(readme): update setup and prompts for Bun package manager

### DIFF
--- a/.github/instructions/EXPO-TEST-SETUP.instructions.md
+++ b/.github/instructions/EXPO-TEST-SETUP.instructions.md
@@ -81,7 +81,7 @@ Configuration is located in `jest.config.ts`. It uses the `jest-expo` preset.
   "scripts": {
     "test": "jest --watch --coverage=false --changedSince=origin/main",
     "test:coverage": "jest --coverage",
-    "testFinal": "pnpx jest"
+    "testFinal": "bunx jest"
   }
 }
 ```

--- a/.github/prompts/EXPO-DOC-README-CREATE.prompt.md
+++ b/.github/prompts/EXPO-DOC-README-CREATE.prompt.md
@@ -13,14 +13,14 @@ The structure should follow the formatting and sections of the provided example,
     *   **Target Audience**: Product people, designers, and developers.
 
 2.  **Quick Start**
-    *   Sequential steps for getting started quickly using `pnpm`.
-    *   **Create Project**: `pnpx create-expo --template ...`
-    *   **Install**: `pnpm install`
-    *   **Run**: `pnpm start` (with instructions to scan QR code).
+    *   Sequential steps for getting started quickly using `bun`.
+    *   **Create Project**: `bunx create-expo --template ...`
+    *   **Install**: `bun install`
+    *   **Run**: `bun start` (with instructions to scan QR code).
 
 3.  **Helpful Commands**
     *   List specific useful commands identified in `package.json`.
-    *   Examples: `pnpm run eas-preview`, `pnpm run storybook:start`.
+    *   Examples: `bun run eas-preview`, `bun run storybook:start`.
 
 4.  **Project Structure (Where to look in the code)**
     *   Map the file system to a user-friendly guide.
@@ -39,12 +39,12 @@ The structure should follow the formatting and sections of the provided example,
     *   **Styling**: Styled Components / StyleSheet / Theme tokens.
 
 6.  **Deployment (AppStore / PlayStore / Web)**
-    *   **Build**: Instructions for EAS Build (`pnpm run build:prod`).
-    *   **Updates (OTA)**: Instructions for EAS Update (`pnpm run update:prod`).
+    *   **Build**: Instructions for EAS Build (`bun run build:prod`).
+    *   **Updates (OTA)**: Instructions for EAS Update (`bun run update:prod`).
 
 7.  **Reset Project & Tools**
-    *   Instructions for the custom reset script: `pnpm run reset-project`.
-    *   Instructions for asset generation: `pnpm run generate:branding`.
+    *   Instructions for the custom reset script: `bun run reset-project`.
+    *   Instructions for asset generation: `bun run generate:branding`.
 
 8.  **Connect & Support (Preserve Existing)**
     *   **Portfolio**: Link to binnicordova.com.
@@ -57,7 +57,7 @@ The structure should follow the formatting and sections of the provided example,
 *   **Preserve Branding**: Do NOT remove the "Binni Cordova" header, footer, or contact details.
 *   **Preserve Custom Scripts**: Ensure `reset-project` and `generate:branding` commands are documented.
 *   It must reflect the actual structure (`src/`, `assets/`) and scripts from `package.json`.
-*   Instructions must be copy-pasteable and verifyable (prefer `pnpm`).
+*   Instructions must be copy-pasteable and verifyable (prefer `bun`).
 
 ## Usage Example
 

--- a/.github/prompts/EXPO-RELEASE-NEXT-VERSION.promp.md
+++ b/.github/prompts/EXPO-RELEASE-NEXT-VERSION.promp.md
@@ -17,8 +17,8 @@ Please follow these steps to release the next version of the app:
         -   `build:prod`
         -   `build:prod:android`
         -   `build:prod:ios`
-    -   Run the selected command in the terminal (using `pnpm run <command>` or `npm run <command>`).
+    -   Run the selected command in the terminal (using `bun run <command>`).
 
 3.  **Update**:
     -   After the build command has been executed, run the production update command:
-        -   `pnpm run update:prod` or `npm run update:prod`
+        -   `bun run update:prod`

--- a/.github/skills/expo-architect/SKILL.md
+++ b/.github/skills/expo-architect/SKILL.md
@@ -91,7 +91,7 @@ src/components/MyComponent/
 
 ## Code Standards
 
-- **Formatting**: We use **Biome**. Run `pnpm format` to ensure code style compliance.
+- **Formatting**: We use **Biome**. Run `bun format` to ensure code style compliance.
 - **TypeScript**: Use path aliases (`@/`) to avoid deep relative paths (e.g., `../../../../utils`).
 - **Unit Testing**: 
   - Mandatory for components with logic, hooks, and stores.

--- a/.github/skills/expo-atomic/SKILL.md
+++ b/.github/skills/expo-atomic/SKILL.md
@@ -74,9 +74,9 @@ Specific instances of templates where the UI is rendered with real data and busi
 1.  **Identify the Level**: Determine if the new UI requirement is an Atom, Molecule, or Organism.
 2.  **Define Styles**: Use tokens from `src/theme/` in your `.styles.ts`.
 3.  **Implement**: Create the component following the Folder-per-Component pattern.
-4.  **Document**: Create a `.stories.tsx` file and run `pnpm storybook-generate` to validate visually.
+4.  **Document**: Create a `.stories.tsx` file and run `bun storybook-generate` to validate visually.
 5.  **Test**: Write unit tests in `.test.tsx` to ensure functionality and accessibility.
 
 ## Documentation
 
-All components across the atomic spectrum are documented in **Storybook**, which acts as our living design system documentation. Run `pnpm storybook:web` to explore the inventory.
+All components across the atomic spectrum are documented in **Storybook**, which acts as our living design system documentation. Run `bun storybook:web` to explore the inventory.

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-pnpm dlx commitlint --edit $1
+bunx commitlint --edit $1

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ I've crafted this boilerplate using my 8+ years of experience as an Expo develop
 ## Quick start
 
 1. Prerequisites:
+- **Bun**: v1.1 or newer (Our recommended and favorite manager)
 - **Node.js**: v20 or newer (LTS recommended)
-- **pnpm** or **bun** (preferred over npm/yarn)
 
-2. Create your new app from my template (keeps `.github`, removes git history):
+1. Create your new app from my template (keeps `.github`, removes git history):
 
 ```sh
 git clone --depth 1 https://github.com/binnicordova/expo-boilerplate.git my-app && cd my-app && rm -rf .git && git init
@@ -31,20 +31,28 @@ git clone --depth 1 https://github.com/binnicordova/expo-boilerplate.git my-app 
 If you use `create-expo --template`, some template files (including AI setup under `.github`) can be skipped:
 
 ```sh
-pnpx create-expo --template https://github.com/binnicordova/expo-boilerplate
+bunx create-expo --template https://github.com/binnicordova/expo-boilerplate
 ```
+or use pnpx, npx, yarn...
 
 2. Install dependencies:
 
 ```sh
-pnpm install
+bun install
 ```
 
 3. Run and preview on your iPhone or Android device (scan the QR in Expo Go):
 
 ```sh
-pnpm start
+bun start
 ```
+Download [Expo Go Android](https://play.google.com/store/apps/details?id=host.exp.exponent&hl=en_US) or
+[Expo Go iPhone](https://apps.apple.com/us/app/expo-go/id982107779)
+
+4. Optionally, launch on devices or emulators from the terminal:
+- Press **i** to open on iOS simulator.
+- Press **a** to open on Android emulator.
+- Press **w** to open on web browser.
 
 ## TV Support (Apple TV & Android TV)
 
@@ -60,18 +68,18 @@ I've made this boilerplate safe for TV devices at runtime (notifications and bac
 Recommended TV flow:
 
 ```sh
-pnpm install
-pnpm ios # or pnpm android
+bun install
+bun ios # or bun android
 ```
 
 Then select your TV simulator or device from your native tooling.
 
 ## Helpful commands
 
-- **Preview on a device**: `pnpm run eas-preview`
-- **Run component stories**: `pnpm run storybook:start`
-- **Browse stories on the web**: `pnpm run storybook:web` 🌐
-- **Run tests**: `pnpm run test`
+- **Preview on a device**: `bun run eas-preview`
+- **Run component stories**: `bun run storybook:start`
+- **Browse stories on the web**: `bun run storybook:web` 🌐
+- **Run tests**: `bun run test`
 
 ## Where to look in my code (Project Structure)
 
@@ -103,12 +111,12 @@ When you’re ready to publish, use **EAS (Expo Application Services)**:
 
 **Build for Production:**
 ```sh
-pnpm run build:prod
+bun run build:prod
 ```
 
 **Update over the Air (OTA):**
 ```sh
-pnpm run update:prod
+bun run update:prod
 ```
 
 ## Reset Project & Tools
@@ -116,13 +124,13 @@ pnpm run update:prod
 **Reset the Project:**
 To reset the project and remove all example code, run the following command:
 ```sh
-pnpm run reset-project
+bun run reset-project
 ```
 
 **Generate Branding Assets:**
 To generate all required app icons and store assets, simply provide a square `logo.png` or `logo.svg` (recommend 1024x1024) in the `scripts/` folder and run:
 ```sh
-pnpm run generate:branding
+bun run generate:branding
 ```
 This script asks you the image path, and automatically populates all different required sizes and splashes for Expo and the App/Play Stores.
 
@@ -172,8 +180,8 @@ I leverage a high-velocity AI workflow to transform concepts into scaled product
 2. **AI-First Design**: I utilize [**STICH Google AI**](https://stitch.withgoogle.com) (Gemma/Gemini) to generate high-fidelity design strategies. I don't just ask for "a UI"—I ask for a design system that works with Expo's primitives.
 3. **Agentic Scaffolding**: I use **GitHub Copilot** or **Cursor** to modify this boilerplate. I ALWAYS anchor the session to my custom **Agent Skills** (like `#expo-architect`) to ensure every line of code generated follows the **Screaming Architecture** and **Atomic Design** principles from day one, based on the generated AI design.
 4. **Res resilient Modeling**: Before writing UI, I define my data models and Jotai atoms. I use the AI to generate the `src/models/` and `src/stores/` layers, creating a type-safe foundation for the entire app.
-5. **Continuous CI/CD (EAS)**: I generate builds using **EAS**. I use `pnpm run build:prod` (or `bun run build:prod`) to push to the cloud, letting the CI handle the heavy lifting while I continue developing.
-6. **The "No-Wait" Release (OTA)**: Traditional store reviews kill momentum. I bypass them for UI tweaks and logic fixes using **Over-the-Air (OTA)** updates via `pnpm run update:prod` (or `bun run update:prod`), pushing changes directly to users in seconds.
+5. **Continuous CI/CD (EAS)**: I generate builds using **EAS**. I use `bun run build:prod` to push to the cloud, letting the CI handle the heavy lifting while I continue developing.
+6. **The "No-Wait" Release (OTA)**: Traditional store reviews kill momentum. I bypass them for UI tweaks and logic fixes using **Over-the-Air (OTA)** updates via `bun run update:prod`, pushing changes directly to users in seconds.
 7. **KPI-Driven Iteration**: I monitor analytics and use AI to transform raw user data into actionable feature requests or bug fixes, maintaining a constant state of improvement.
 
 ## 🚀 What you can build with this Boilerplate

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "test": "jest --watch --coverage=false --changedSince=origin/main",
         "test:coverage": "jest --coverage",
         "testDebug": "jest -o --watch --coverage=false",
-        "testFinal": "pnpx jest",
+        "testFinal": "bunx jest",
         "testCoverage": "jest --coverage",
         "updateSnapshots": "jest -u --coverage=false",
         "format": "biome format --write --files-ignore-unknown=true && biome ci .",

--- a/scripts/reset-project.js
+++ b/scripts/reset-project.js
@@ -284,9 +284,7 @@ async function main() {
         console.log(`
 🚀  Run
 
-\`npx expo start\`
-or
-\`pnpm start\`
+\`bun start\`
 
 to begin your fresh project with this minimal setup.
 Enjoy building with my Expo Boilerplate! 🎉


### PR DESCRIPTION
## Summary
This PR standardizes project documentation and helper prompts around Bun as the primary package manager, so local setup and contributor workflows remain consistent.

## Changes
- Updated Bun-oriented setup guidance in README and related prompt files
- Adjusted skill/prompt wording to reflect Bun-based workflows
- Updated commit hook and reset script references for consistency
- Applied minor documentation cleanup in touched files

## Testing Status
- [ ] Unit tests passing (not run; changes are docs/config only and do not modify src runtime logic)
- [ ] Coverage > 80% (not re-run; baseline expected unchanged)
- [ ] Verified on Web/iOS/Android (not applicable for docs/config-only changes)

## Breaking Changes
- None

## Screenshots/Videos (if UI)
- Not applicable